### PR TITLE
fix(deps): bump brace-expansion to 1.1.16/2.1.3 (GHSA-3jxr-9vmj-r5cp)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1654,9 +1654,9 @@
       }
     },
     "node_modules/@jest/reporters/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2578,9 +2578,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3869,9 +3869,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4663,9 +4663,9 @@
       }
     },
     "node_modules/jest-config/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5226,9 +5226,9 @@
       }
     },
     "node_modules/jest-runtime/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7519,9 +7519,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Resolves Dependabot alerts **31** and **32** — both `GHSA-3jxr-9vmj-r5cp` (brace-expansion: DoS via exponential-time expansion of consecutive non-expanding `{}` groups). GitHub severity **high**, CVSS v3 5.3 / CVSS v4 7.7, CWE-400 + CWE-407. Both alerts are **development** scope against `package-lock.json`.

Alert 31 range `< 1.1.16` and alert 32 range `>= 2.0.0, < 2.1.2`.

## Change

Lockfile-only. All six `brace-expansion` entries were deleted and re-resolved with **npm 10.9.8** (CI pins Node 20 / npm 10, so the lock must not be written by npm 11). Every target sits inside the parent's already-declared semver range, so **no `package.json` change and no `overrides` entry is needed**.

| lockfile path | before | after |
|---|---|---|
| `node_modules/brace-expansion` | 1.1.13 | 1.1.16 |
| `node_modules/@jest/reporters/node_modules/brace-expansion` | 2.0.3 | 2.1.3 |
| `node_modules/glob/node_modules/brace-expansion` | 2.0.3 | 2.1.3 |
| `node_modules/jest-config/node_modules/brace-expansion` | 2.0.3 | 2.1.3 |
| `node_modules/jest-runtime/node_modules/brace-expansion` | 2.0.3 | 2.1.3 |
| `node_modules/test-exclude/node_modules/brace-expansion` | 2.0.3 | 2.1.3 |

Diff is **6 lockfile entries = 18 insertions / 18 deletions** (each entry rewrites `version`, `resolved` and `integrity`). A structural JSON comparison of the lockfile before/after confirms: 599 packages before and after, zero added keys, zero removed keys, exactly 6 changed entries, all `brace-expansion`, all `dev: true`, identical `dependencies`, no `engines` or `peerDependencies` on either target.

## Verification

Advisory-level gate (`npm@10 audit --json`, before vs after):

```
advisories BEFORE: GHSA-3jxr-9vmj-r5cp, GHSA-mh99-v99m-4gvg
advisories AFTER : GHSA-mh99-v99m-4gvg
NEW advisories introduced: []
advisories REMOVED     : ["GHSA-3jxr-9vmj-r5cp"]
```

Local run of exactly what `ci.yml` and `smoke-test.yml` execute (npm 10, no `--ignore-scripts`, real Playwright install):

```
npm ci                      598 packages added, exit 0
npm run validate:html       exit 0
npm run validate:css        exit 0
npm run validate:js         exit 0  (13 pre-existing security/detect-object-injection warnings, 0 errors)
npm test                    5 suites / 75 tests passed, exit 0
playwright (smoke-test.yml) 13 passed, exit 0
playwright (ci.yml)         38 passed, 1 failed  <-- pre-existing, see below
```

### About the one E2E failure

`e2e/a11y.spec.js:39 "homepage should have proper heading hierarchy"` fails **identically on unmodified `master`** in the same local environment (38 passed / 1 failed both times). It is an environment artifact: the YouTube and Spotify embed iframes do not load locally, so axe-core scans two empty `<html><head></head><body></body></html>` frames and reports `page-has-heading-one`. `CI` on `master` (8dd5db6) is green, so this does not reproduce on GitHub Actions. It is unrelated to this change — a glob-pattern parser cannot affect axe-core heading detection.

### About the "26 high severity vulnerabilities" npm audit line

This is a **reporting artifact, not a regression**. `GHSA-mh99-v99m-4gvg` was already present before this change and is unchanged by it. Previously npm collapsed it to the single `brace-expansion` leaf because `fixAvailable` was `true`; now that the only remaining advisory has no in-range fix (`fixAvailable: {"name":"eslint","version":"10.8.0","isSemVerMajor":true}`), npm propagates it up to all 26 dependents. The distinct advisory set strictly shrank. Neither CI workflow runs `npm audit`, so nothing is gated on this number.

`GHSA-mh99-v99m-4gvg` is Dependabot alert **34**, already `auto_dismissed` (dev scope) since 2026-07-26. Its range is `<= 5.0.7` with first patched `5.0.8`; there is no 1.x or 2.x backport, so no brace-expansion version reachable inside minimatch's declared ranges clears it. Do not chase it — npm's own resolver reports the fix as a semver-major eslint jump.

## Not in this PR

Two hygiene items were deliberately left out to keep this a clean, lockfile-only security change:

1. `netlify.toml` has `publish = "."`, which publishes the whole repo root. `package.json`, `package-lock.json`, `CLAUDE.md`, `README.md`, `eslint.config.js`, `jest.config.js`, `playwright.config.js`, `js/main.js`, `__tests__/main.test.js` and the `e2e/*.spec.js` files are all live-reachable on the production domain.
2. No `.github/dependabot.yml` exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
